### PR TITLE
[FIX] auth/signout,refresh Implement changed

### DIFF
--- a/apps/user-app/src/auth/interfaces/jwt.interface.ts
+++ b/apps/user-app/src/auth/interfaces/jwt.interface.ts
@@ -1,6 +1,5 @@
 export interface IJwtPayLoad {
   id: number;
-  nickname: string;
-  iat: number;
-  exp: number;
+  iat?: number;
+  exp?: number;
 }

--- a/apps/user-app/src/report/report.service.ts
+++ b/apps/user-app/src/report/report.service.ts
@@ -7,12 +7,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { isInstance } from 'class-validator';
-import {
-  EntityNotFoundError,
-  QueryFailedError,
-  Raw,
-  Repository,
-} from 'typeorm';
+import { QueryFailedError, Raw, Repository } from 'typeorm';
 import { CreateReportDto } from './dto/create-report.dto';
 import { Report } from './entities/report.entity';
 

--- a/apps/user-app/src/social/social.service.ts
+++ b/apps/user-app/src/social/social.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   NotAcceptableException,
   ServiceUnavailableException,
@@ -24,7 +25,11 @@ export class SocialService {
         },
       });
     } catch (err) {
-      throw new ServiceUnavailableException('social Service UnAvailable');
+      if (err['code'] === 'ERR_BAD_REQUEST') {
+        throw new BadRequestException('Token Invalid or Expired');
+      } else {
+        throw new ServiceUnavailableException('social Service UnAvailable');
+      }
     }
   }
 
@@ -44,11 +49,43 @@ export class SocialService {
           code: code,
         }),
       });
-      return socialToken['data']['access_token'];
+      return [
+        socialToken['data']['access_token'],
+        socialToken['data']['refresh_token'],
+      ];
     } catch (err) {
-      throw new ServiceUnavailableException('social Service UnAvailable');
+      if (err['code'] === 'ERR_BAD_REQUEST') {
+        throw new BadRequestException('Token Invalid or Expired');
+      } else {
+        throw new ServiceUnavailableException('social Service UnAvailable');
+      }
     }
   }
+  async refreshToken(token: string) {
+    try {
+      const socialToken = await axios({
+        method: 'POST',
+        url: 'https://kauth.kakao.com/oauth/token',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        data: stringify({
+          grant_type: 'refresh_token',
+          client_id: process.env.CLIENT_ID,
+          client_secret: process.env.CLIENT_SECRET,
+          refresh_token: token,
+        }),
+      });
+      return socialToken['data']['access_token'];
+    } catch (err) {
+      if (err['code'] === 'ERR_BAD_REQUEST') {
+        throw new BadRequestException('Token Invalid or Expired');
+      } else {
+        throw new ServiceUnavailableException('social Service UnAvailable');
+      }
+    }
+  }
+
   async logout(socialToken: string) {
     try {
       return await axios({
@@ -59,7 +96,11 @@ export class SocialService {
         },
       });
     } catch (err) {
-      throw new ServiceUnavailableException('social Service UnAvailable');
+      if (err['code'] === 'ERR_BAD_REQUEST') {
+        throw new BadRequestException('Token Invalid or Expired');
+      } else {
+        throw new ServiceUnavailableException('social Service UnAvailable');
+      }
     }
   }
   async unlink(socialToken: string) {
@@ -72,8 +113,11 @@ export class SocialService {
         },
       });
     } catch (err) {
-      throw new ServiceUnavailableException('social Service UnAvailable');
+      if (err['code'] === 'ERR_BAD_REQUEST') {
+        throw new BadRequestException('Token Invalid or Expired');
+      } else {
+        throw new ServiceUnavailableException('social Service UnAvailable');
+      }
     }
-    // TODO Unlink Target User on db.
   }
 }

--- a/apps/user-app/src/users/users.service.ts
+++ b/apps/user-app/src/users/users.service.ts
@@ -8,7 +8,13 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { isInstance } from 'class-validator';
-import { DeleteResult, EntityNotFoundError, Raw, Repository } from 'typeorm';
+import {
+  DeleteResult,
+  EntityNotFoundError,
+  Raw,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';


### PR DESCRIPTION
auth.signout (make difference also to our model)

	-  softDelete the Auth model
		- if login back again, reverts deletedAt as null

auth.refresh (Need for logout, signout)

	- can refresh Social Refresh token, Signature has no changes.
	- if signature is 56 size long, define as social one.
	- if not, define as our refresh token.